### PR TITLE
fix trackWithProperties param order

### DIFF
--- a/sdk/O2MTracker/O2MC.h
+++ b/sdk/O2MTracker/O2MC.h
@@ -91,9 +91,9 @@
 /**
  * Tracks an event with additional data.
  * Essentially adds a new event with the String parameter as name and any additonal properties.
- * @param eventName name of tracked event
  * @param properties anything you'd like to keep track of
+ * @param eventName name of tracked event
  */
--(void)trackWithProperties:(nonnull NSString*)eventName properties:(nonnull NSDictionary*)properties;
+-(void)trackWithProperties:(nonnull NSDictionary*)properties eventName:(nonnull NSString*)eventName;
 
 @end

--- a/sdk/O2MTracker/O2MC.m
+++ b/sdk/O2MTracker/O2MC.m
@@ -90,8 +90,8 @@
     [self->_tracker track:eventName];
 }
 
--(void)trackWithProperties:(nonnull NSString*)eventName properties:(nonnull NSDictionary*)properties; {
-    [self->_tracker trackWithProperties:eventName properties:properties];
+-(void)trackWithProperties:(nonnull NSDictionary*)properties eventName:(nonnull NSString*)eventName; {
+    [self->_tracker trackWithProperties:properties eventName:eventName];
 }
 
 @end

--- a/sdk/O2MTracker/O2MTagger.h
+++ b/sdk/O2MTracker/O2MTagger.h
@@ -64,9 +64,8 @@
 /**
  * Tracks an event with additional data.
  * Essentially adds a new event with the String parameter as name and any additonal properties.
- * @param eventName name of tracked event
  * @param properties anything you'd like to keep track of
+ * @param eventName name of tracked event
  */
--(void)trackWithProperties:(NSString*)eventName properties:(NSDictionary*)properties;
-
+-(void)trackWithProperties:(NSDictionary*)properties eventName:(NSString*)eventName;
 @end

--- a/sdk/O2MTracker/O2MTagger.m
+++ b/sdk/O2MTracker/O2MTagger.m
@@ -149,7 +149,7 @@
     });
 }
 
--(void)trackWithProperties:(NSString*)eventName properties:(NSDictionary*)properties;
+-(void)trackWithProperties:(NSDictionary*)properties eventName:(NSString*)eventName;
 {
     dispatch_async(_tagQueue, ^{
         if (![self->_batchManager isDispatching]) return;

--- a/sdk/O2MTracker/UIViewController.m
+++ b/sdk/O2MTracker/UIViewController.m
@@ -53,14 +53,14 @@
     [self O2M_viewDidAppear:animated];
 
     // Track viewDidAppear event
-    [[O2MC sharedInstance] trackWithProperties:@"viewStart" properties:@{@"name": NSStringFromClass([self class])}];
+    [[O2MC sharedInstance] trackWithProperties:@{@"name": NSStringFromClass([self class])} eventName:@"viewStart"];
 }
 
 - (void)O2M_viewWillDisappear:(BOOL)animated; {
     [self O2M_viewWillDisappear:(BOOL)animated];
 
     // Track viewDidDisappear event
-    [[O2MC sharedInstance] trackWithProperties:@"viewStop" properties:@{@"name": NSStringFromClass([self class])}];
+    [[O2MC sharedInstance] trackWithProperties:@{@"name": NSStringFromClass([self class])} eventName:@"viewStop"];
 }
 
 @end


### PR DESCRIPTION
Use the conventional way of naming methods and ordering parameters.

fixes O2MC/moby-tracking-sdk/issues/145